### PR TITLE
DEC-424 Update mime-types gem to save on RAM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 group :application do
+  # Only load required mime types to save on RAM
+  gem "mime-types", "~> 2.6.1", require: "mime/types/columnar"
   # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
   gem 'rails', '4.2.0.rc1'
   # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mini_portile (0.6.1)
     minitest (5.4.3)
     multi_json (1.10.1)
@@ -287,6 +287,7 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.0)
   jquery-rails
+  mime-types (~> 2.6.1)
   newrelic_rpm
   rails (= 4.2.0.rc1)
   rb-readline


### PR DESCRIPTION
**WHAT** Update mime-types gem
**WHY** To save on up to 20% RAM usage