### PR TITLE
DEC-1086 Upgrade ruby-vips

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,8 +93,12 @@ GEM
       addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.6)
     formatador (0.2.5)
+    glib2 (3.0.8)
+      pkg-config
     globalid (0.3.0)
       activesupport (>= 4.1.0)
+    gobject-introspection (3.0.8)
+      glib2 (= 3.0.8)
     growl (1.0.3)
     guard (2.6.1)
       formatador (>= 0.2.4)
@@ -146,6 +150,7 @@ GEM
     newrelic_rpm (3.11.2.286)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    pkg-config (1.1.7)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -211,7 +216,8 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    ruby-vips (0.3.9)
+    ruby-vips (1.0.0)
+      gobject-introspection (~> 3.0)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -302,3 +308,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/services/create_image_derivative.rb
+++ b/app/services/create_image_derivative.rb
@@ -38,6 +38,6 @@ class CreateImageDerivative
     end
 
     def source_image
-      @source_image ||= VIPS::Image.new(source_filepath)
+      @source_image ||= Vips::Image.new(source_filepath)
     end
 end

--- a/app/services/create_pyramid_tiff.rb
+++ b/app/services/create_pyramid_tiff.rb
@@ -3,19 +3,21 @@ require 'vips'
 class CreatePyramidTiff < CreateImageDerivative
   PYRAMID_TIFF_OPTIONS = {
     compression: :jpeg,
-    quality: 80,
-    multi_res: :pyramid,
-    tile_size: [256, 256]
+    Q: 80,
+    pyramid: true,
+    tile_width: 256,
+    tile_height: 256
   }
 
   private
 
     def create_derivative!
-      tiff_writer.write(target_filepath)
+      puts source_image.inspect
+      source_image.tiffsave(target_filepath, PYRAMID_TIFF_OPTIONS)
     end
 
     def tiff_writer
-      @tiff_writer ||= VIPS::TIFFWriter.new(source_image, PYRAMID_TIFF_OPTIONS)
+      @tiff_writer ||= Vips::Image.new(source_image)
     end
 
 end

--- a/app/services/create_thumbnail.rb
+++ b/app/services/create_thumbnail.rb
@@ -3,11 +3,11 @@ require 'vips'
 class CreateThumbnail < CreateImageDerivative
   private
     def source_width
-      source_image.x_size
+      source_image.width
     end
 
     def source_height
-      source_image.y_size
+      source_image.height
     end
 
     def aspect_ratio

--- a/spec/services/create_image_derivative_spec.rb
+++ b/spec/services/create_image_derivative_spec.rb
@@ -23,7 +23,7 @@ describe CreateImageDerivative do
 
   describe '#source_image' do
     it "creates a VIPS::Image" do
-      expect(subject.send(:source_image)).to be_a_kind_of(VIPS::Image)
+      expect(subject.send(:source_image)).to be_a_kind_of(Vips::Image)
     end
   end
 

--- a/spec/services/create_pyramid_tiff_spec.rb
+++ b/spec/services/create_pyramid_tiff_spec.rb
@@ -9,9 +9,9 @@ describe CreatePyramidTiff do
 
   describe '#tiff_writer' do
     it "creates a VIPS::TIFFWriter with the source image" do
-      source_image = instance_double(VIPS::Image)
+      source_image = instance_double(Vips::Image)
       expect(subject).to receive(:source_image).and_return(source_image)
-      expect(VIPS::TIFFWriter).to receive(:new).with(source_image, described_class::PYRAMID_TIFF_OPTIONS).and_return('tiff_writer')
+      expect(Vips::Image).to receive(:new).with(source_image).and_return("tiff_writer") # , described_class::PYRAMID_TIFF_OPTIONS).and_return('tiff_writer')
       expect(subject.send(:tiff_writer)).to eq('tiff_writer')
     end
   end
@@ -31,9 +31,9 @@ describe CreatePyramidTiff do
       expect(File.exist?(target_filepath)).to be_falsy
       subject.send(:create_derivative!)
       expect(File.exist?(target_filepath)).to be_truthy
-      original = VIPS::Image.new(source_filepath)
-      pyramid = VIPS::Image.new(target_filepath)
-      expect(pyramid.size).to eq(original.size)
+      original = Vips::Image.new(source_filepath)
+      pyramid = Vips::Image.new(target_filepath)
+      expect(pyramid.width).to eq(original.width)
     end
   end
 

--- a/spec/services/create_thumbnail_spec.rb
+++ b/spec/services/create_thumbnail_spec.rb
@@ -64,8 +64,9 @@ RSpec.describe CreateThumbnail do
       expect(File.exist?(target_filepath)).to be_falsy
       subject.send(:create_derivative!)
       expect(File.exist?(target_filepath)).to be_truthy
-      thumbnail = VIPS::Image.new(target_filepath)
-      expect(thumbnail.size).to eq([150, 200])
+      thumbnail = Vips::Image.new(target_filepath)
+      expect(thumbnail.width).to eq 150
+      expect(thumbnail.height).to eq 200
     end
   end
 end


### PR DESCRIPTION
What: Upgraded ruby-vips in order to fix a problem in my dev environment.
How: In addition to the gem upgrade, some of the code needed to be refactored so that it's conformant with the new gem API syntax.

**Caveat** On my system, I'm running vips-8.3.0-Mon Apr 18 13:21:17 PDT 2016. Others may be running an older version of vips such as vips-7.42.2-Mon Feb  9 09:02:03 GMT 2015. The gem is under new stewardship, and the change was partially made in order to bring ruby-vips into compliance with the current version of vips, which is version 8.