### PR TITLE
DEC-637 Unicode

### DIFF
--- a/app/services/add_image.rb
+++ b/app/services/add_image.rb
@@ -34,7 +34,7 @@ class AddImage
 
   private
     def filename
-      image.original_filename
+      SecureRandom.urlsafe_base64 + File.extname(image.original_filename)
     end
 
     def basepath

--- a/spec/services/add_image_spec.rb
+++ b/spec/services/add_image_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AddImage do
 
   describe '#filepath' do
     it "expands the group and item id into multiple directories" do
-      expect(subject.filepath).to eq("application/000/001/000/002/testimage.jpg")
+      expect(subject.filepath).to include("application/000/001/000/002/", ".jpg")
     end
   end
 


### PR DESCRIPTION
Ruby+filesystem has a tough time with unicode file names. On Mac, we could create thumbnails but not search for them because mac uses "UTF8-MAC" but ruby just interprets this as "UTF-8" which is encoded differently. 

On Linux, we can't even create thumbnails, presumably because we're uploading files in "UTF8-MAC" format which linux has no idea what do.

Instead, we'll just ignore the filename altogether and use a url-safe uuid. Thus ruby and mac/linux will be happy and just use ASCII characters. 
