### PR TITLE
Make image processing more effiecient

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,4 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,5 +9,3 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
-//
-//= require_tree .

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -42,6 +42,10 @@ class ImageSet
     full_filepath(File.join(style.to_s, derivative_basename))
   end
 
+  def working_filepath(derivative_basename = basename)
+    derivative_filepath(:working, derivative_basename)
+  end
+
   def derivatives
     @derivatives ||= build_derivatives
   end

--- a/app/services/convert_image.rb
+++ b/app/services/convert_image.rb
@@ -16,6 +16,7 @@ class ConvertImage
   end
 
   def convert!
+    create_working_image!
     create_pyramid_tiff!
     create_thumbnails!
   end
@@ -25,8 +26,16 @@ class ConvertImage
       image_set.original_filepath
     end
 
+    def source_working_image
+      image_set.working_filepath
+    end
+
+    def create_working_image!
+      CreateThumbnail.call(source_filepath, source_working_image, working_copy_options)
+    end
+
     def create_pyramid_tiff!
-      CreatePyramidTiff.call(source_filepath, image_set.pyramid_filepath)
+      CreatePyramidTiff.call(source_working_image, image_set.pyramid_filepath)
     end
 
     def create_thumbnails!
@@ -36,7 +45,29 @@ class ConvertImage
     end
 
     def create_thumbnail!(style, options)
-      CreateThumbnail.call(source_filepath, image_set.thumbnail_filepath(style), options)
+      CreateThumbnail.call(source_working_image, image_set.thumbnail_filepath(style), options)
+    end
+
+    def source_image
+      @source_image ||= VIPS::Image.new(source_filepath)
+    end
+
+    def source_width
+      source_image.x_size
+    end
+
+    def source_height
+      source_image.y_size
+    end
+
+    def working_copy_options
+      out = {}
+      if source_height > source_width
+        out[:height] = source_height > 3999 ? 4000 : source_height
+      else
+        out[:width] = source_width > 3999 ? 4000 : source_width
+      end
+      out
     end
 
 end

--- a/app/services/create_thumbnail.rb
+++ b/app/services/create_thumbnail.rb
@@ -19,15 +19,14 @@ class CreateThumbnail < CreateImageDerivative
     end
 
     def calculate_size
-      if options[:height]
+      if options[:height] && options[:height] < source_height
         width = (options[:height] * aspect_ratio).round
         [width, options[:height]]
-      elsif options[:width]
+      elsif options[:width] && options[:width] < source_width
         height = (options[:width] / aspect_ratio).round
         [options[:width], height]
       else
-        options[:size] ||= 128
-        [options[:size], options[:size]]
+        [source_width, source_height]
       end
     end
 

--- a/app/services/create_thumbnail.rb
+++ b/app/services/create_thumbnail.rb
@@ -72,6 +72,7 @@ class CreateThumbnail < CreateImageDerivative
     end
 
     def thumbnail_command
+      puts vips_command_array.join(' ')
       vips_command_array.join(' ')
     end
 

--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -24,8 +24,7 @@ Rails.application.configure do
   config.serve_static_assets = false
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,8 +24,7 @@ Rails.application.configure do
   config.serve_static_assets = false
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/spec/services/convert_image_spec.rb
+++ b/spec/services/convert_image_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ConvertImage do
   subject { described_class.new(image_set) }
 
-  let(:image_set) { instance_double(ImageSet, original_filepath: 'source', pyramid_filepath: 'pyramid_target') }
+  let(:image_set) { instance_double(ImageSet, working_filepath: "working", original_filepath: 'source', pyramid_filepath: 'pyramid_target') }
 
   describe 'self' do
     subject { described_class }
@@ -18,16 +18,17 @@ describe ConvertImage do
   end
 
   describe '#convert!' do
-    it 'calls #create_pyramid_tiff! and #create_thumbnails!' do
+    it 'calls #create_pyramid_tiff! and #create_thumbnails! and create_working_image!' do
       expect(subject).to receive(:create_pyramid_tiff!)
       expect(subject).to receive(:create_thumbnails!)
+      expect(subject).to receive(:create_working_image!)
       subject.convert!
     end
   end
 
   describe '#create_pyramid_tiff!' do
     it 'calls CreatePyramidTiff' do
-      expect(CreatePyramidTiff).to receive(:call).with('source', 'pyramid_target')
+      expect(CreatePyramidTiff).to receive(:call).with('working', 'pyramid_target')
       subject.send(:create_pyramid_tiff!)
     end
   end
@@ -43,7 +44,7 @@ describe ConvertImage do
   describe '#create_thumbnail!' do
     it 'calls CreateThumbnail' do
       expect(image_set).to receive(:thumbnail_filepath).with(:small).and_return('small')
-      expect(CreateThumbnail).to receive(:call).with('source', 'small', {height: 200})
+      expect(CreateThumbnail).to receive(:call).with('working', 'small', {height: 200})
       subject.send(:create_thumbnail!, :small, {height: 200})
     end
   end

--- a/spec/services/create_thumbnail_spec.rb
+++ b/spec/services/create_thumbnail_spec.rb
@@ -19,17 +19,23 @@ RSpec.describe CreateThumbnail do
       expect(subject.send(:size)).to eq [150, 200]
     end
 
-    it "returns a square bounding box" do
-      options[:size] = 200
-      expect(subject.send(:size)).to eq [200, 200]
+    it "returns the source width if the set width is greater than the actual width" do
+      options[:width] = 2000
+      expect(subject.send(:size)).to eq [1200, 1600]
     end
+
+    it "returns the source height if the set height is greater than the actual heith" do
+      options[:height] = 2000
+      expect(subject.send(:size)).to eq [1200, 1600]
+    end
+
   end
 
   describe '#vips_command_array' do
     it 'returns an array of the command and arguments' do
       expect(subject.send(:vips_command_array)).to eq([
         Rails.configuration.settings.vips_thumbnail_command,
-        "-s 128x128",
+        "-s 1200x1600",
         "-o #{target_filepath}[Q=60]",
         source_filepath,
       ])


### PR DESCRIPTION
I added a step to honeypot to preprocess the image to a smaller size that we use to speed up future transitions. 

Largely this was done by updating how createThumbnail works so that it does not make images larger. 
Then adding a process step in front of the other steps to create a working image.  
Then I used the working image in the future processing. 

