### PR TITLE
More containerization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Set up Ruby
-      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-      # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      # uses: ruby/setup-ruby@v1
-        uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.4
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,27 @@ services:
       RAILS_LOG_LEVEL: DEBUG
       # Do not use this value in actual production env
       SECRET_KEY_BASE: e08359113980fceb3b62152286866deac83789900db39acd16712910259d904089a53ebebf614db39844ddd467f004ae426424095083b447d9173c0ee6041de2
+  iip:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.iip
+    environment:
+      VERBOSITY: 5
+      LOGFILE: /dev/stdout
+      MAX_IMAGE_CACHE_SIZE: 10
+      JPEG_QUALITY: 50
+      MAX_CVT: 3000
+      MEMCACHED_SERVERS: localhost
+      FILESYSTEM_PREFIX: /mnt/efs # Relies on the request uri having /images and that there's a subdir /mnt/efs/images
+      CORS: "*"
+    volumes_from:
+      # Get static assets from the rails container
+      - honeypot:ro
+    volumes:
+      # Locally, the honeypot container will mount the local dir, so the uploaded images will go into ./public/images
+      # Map this local directory to the mount location in the container. This is to mimic how a persistent file
+      # system will be used when deployed to use EFS
+      - ./public/images:/mnt/efs/images
   nginx:
     build:
       context: .
@@ -19,6 +40,8 @@ services:
       RAILS_HOST: honeypot
       RAILS_PORT: 3019
       RAILS_STATIC_DIR: /honeypot/public
+      IIP_HOST: iip
+      IIP_PORT: 9000
     ports:
       - "80:80"
     volumes_from:

--- a/docker/Dockerfile.iip
+++ b/docker/Dockerfile.iip
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update 
+RUN apt-get install -y iipimage-server
+RUN apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+USER www-data
+ENTRYPOINT ["/usr/lib/iipimage-server/iipsrv.fcgi", "--bind", "0.0.0.0:9000", "--backlog", "1024"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,15 +4,21 @@ upstream app_service {
   server ${RAILS_HOST}:${RAILS_PORT};
 }
 
+upstream iip_service {
+  server ${IIP_HOST}:${IIP_PORT};
+}
+
 server {
   listen 80;
   server_name localhost;
   root ${RAILS_STATIC_DIR};
 
   try_files $uri/index.html $uri @app_service;
+  add_header      Access-Control-Allow-Origin *;
 
   location ~ ^/images/(.*)$ {
       root /mnt/efs;
+      try_files $uri @iip_service;
   }
 
   location @app_service {
@@ -20,6 +26,18 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
+  }
+
+  location @iip_service {
+      fastcgi_pass 	  iip_service;
+      fastcgi_param   PATH_INFO $fastcgi_script_name;
+      fastcgi_param   REQUEST_METHOD $request_method;
+      fastcgi_param   QUERY_STRING DeepZoom=$request_uri;
+      fastcgi_param   CONTENT_TYPE $content_type;
+      fastcgi_param   CONTENT_LENGTH $content_length;
+      fastcgi_param   SERVER_PROTOCOL $server_protocol;
+      fastcgi_param   REQUEST_URI $request_uri;
+      fastcgi_param   HTTPS $https if_not_empty;
   }
 
   error_page 500 502 503 504 /500.html;

--- a/docker/nginx_entry.sh
+++ b/docker/nginx_entry.sh
@@ -3,7 +3,10 @@
 sed -i "s;\${RAILS_HOST};$RAILS_HOST;g" /etc/nginx/conf.d/default.conf
 sed -i "s;\${RAILS_PORT};$RAILS_PORT;g" /etc/nginx/conf.d/default.conf
 sed -i "s;\${RAILS_STATIC_DIR};$RAILS_STATIC_DIR;g" /etc/nginx/conf.d/default.conf
+sed -i "s;\${IIP_HOST};$IIP_HOST;g" /etc/nginx/conf.d/default.conf
+sed -i "s;\${IIP_PORT};$IIP_PORT;g" /etc/nginx/conf.d/default.conf
 
 bash /project_root/wait-for-it.sh -t 120 --strict ${RAILS_HOST}:${RAILS_PORT}
+bash /project_root/wait-for-it.sh -t 120 --strict ${IIP_HOST}:${IIP_PORT}
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
- Added log configuration via env
- Added nginx for serving out static assets from rails, and for serving
out the static images that the API generates. This required a bit of
mounting of files from the rails container into nginx for the static
assets, and separately mounting the shared file system for images. Also
added a few more bits of standard containerization stuff like configuring
log levels.
- Added [IIP](https://iipimage.sourceforge.io/) service to the docker compose. Nginx will pass requests for
tiled images to this upstream service.
- Added the traditional wait-for-it script now that we have more than
one container and dependencies between them
- Added an example curl command to the README of how to test the api